### PR TITLE
connmgr.py: fix "No module named 'StringIO'" with Py3

### DIFF
--- a/connmgr.py
+++ b/connmgr.py
@@ -29,7 +29,7 @@ if hasattr(GLib, "set_prgname"):
 
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gdk, Gio
-from StringIO import StringIO
+from io import StringIO
 
 import os.path
 import shutil


### PR DESCRIPTION
Alternatively use:
try:
    from StringIO import StringIO
except ImportError:
    from io import StringIO

See https://stackoverflow.com/questions/11914472/stringio-in-python3